### PR TITLE
Added features to clear db entries

### DIFF
--- a/src/main/java/io/github/taz/stickybot/App.java
+++ b/src/main/java/io/github/taz/stickybot/App.java
@@ -5,7 +5,7 @@ import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.requests.restaction.CommandListUpdateAction;
 import dev.mccue.json.Json;
 import dev.mccue.json.JsonDecoder;
-
+import io.github.taz.stickybot.listener.ClearDB;
 import io.github.taz.stickybot.listener.MessageContextInteractionListener;
 import io.github.taz.stickybot.listener.MessageReceivedListener;
 import io.github.taz.stickybot.listener.SlashCommandInteractionListener;
@@ -28,10 +28,12 @@ public class App {
 
         CommandListUpdateAction updateAction = jda.updateCommands();
 
-        jda.addEventListener(new MessageReceivedListener());
         jda.addEventListener(new MessageContextInteractionListener(updateAction));
         jda.addEventListener(new SlashCommandInteractionListener(updateAction));
 
         updateAction.queue();
+
+        jda.addEventListener(new MessageReceivedListener());
+        jda.addEventListener(new ClearDB());
     }
 }

--- a/src/main/java/io/github/taz/stickybot/App.java
+++ b/src/main/java/io/github/taz/stickybot/App.java
@@ -9,6 +9,7 @@ import dev.mccue.json.JsonDecoder;
 import io.github.taz.stickybot.listener.MessageContextInteractionListener;
 import io.github.taz.stickybot.listener.MessageReceivedListener;
 import io.github.taz.stickybot.listener.SlashCommandInteractionListener;
+import io.github.taz.stickybot.sticky.StickyMessageUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,14 +22,15 @@ public class App {
         String configString = Files.readString(Path.of(args.length > 0 ? args[0] : "src/main/resources/config.json"));
         configJson = Json.readString(configString);
 
-        JDA bot = JDABuilder.createDefault(JsonDecoder.field(configJson, "token", JsonDecoder::string))
-                .addEventListeners(new MessageReceivedListener())
-                .build();
+        JDA jda = JDABuilder.createDefault(JsonDecoder.field(configJson, "token", JsonDecoder::string)).build();
 
-        CommandListUpdateAction updateAction = bot.updateCommands();
+        StickyMessageUtils.init(jda);
 
-        bot.addEventListener(new MessageContextInteractionListener(updateAction));
-        bot.addEventListener(new SlashCommandInteractionListener(updateAction));
+        CommandListUpdateAction updateAction = jda.updateCommands();
+
+        jda.addEventListener(new MessageReceivedListener());
+        jda.addEventListener(new MessageContextInteractionListener(updateAction));
+        jda.addEventListener(new SlashCommandInteractionListener(updateAction));
 
         updateAction.queue();
     }

--- a/src/main/java/io/github/taz/stickybot/listener/ClearDB.java
+++ b/src/main/java/io/github/taz/stickybot/listener/ClearDB.java
@@ -4,6 +4,7 @@ import io.github.taz.stickybot.sticky.StickyMessageUtils;
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
+// Remove entrey when leave a guild.
 public final class ClearDB extends ListenerAdapter {
     @Override
     public void onGuildLeave(GuildLeaveEvent event) {

--- a/src/main/java/io/github/taz/stickybot/listener/ClearDB.java
+++ b/src/main/java/io/github/taz/stickybot/listener/ClearDB.java
@@ -1,0 +1,12 @@
+package io.github.taz.stickybot.listener;
+
+import io.github.taz.stickybot.sticky.StickyMessageUtils;
+import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+public final class ClearDB extends ListenerAdapter {
+    @Override
+    public void onGuildLeave(GuildLeaveEvent event) {
+        StickyMessageUtils.removeGuild(event.getGuild().getIdLong());
+    }
+}


### PR DESCRIPTION
1. Added a check to only add available channels on startup.
2. Added a listener to remove db entries when bot lefts a guild.
